### PR TITLE
Fix/msw 404에러해결

### DIFF
--- a/src/mocks/index.ts
+++ b/src/mocks/index.ts
@@ -1,10 +1,10 @@
 const initMSW = async () => {
   if (typeof window === 'undefined') {
     const { server } = await import('./server');
-    server.listen();
+    return server.listen();
   } else {
     const { worker } = await import('./browser');
-    worker.start({
+    return worker.start({
       onUnhandledRequest: (req) => {
         if (req.url.startsWith('/_next/static/')) {
           return;

--- a/src/mocks/msw-provider.tsx
+++ b/src/mocks/msw-provider.tsx
@@ -1,20 +1,18 @@
 import { PropsWithChildren, useEffect, useState } from 'react';
 import { initMSW } from '.';
 
-const isAPIMockingMode = process.env.NEXT_PUBLIC_API_MOCKING === 'enabled';
-
 const MSWProvider = ({ children }: PropsWithChildren) => {
   const [isReady, setIsReady] = useState(false);
-
+  
   useEffect(() => {
-    const init = async () => {
-      if (isAPIMockingMode) {
-        await initMSW();
-        setIsReady(true);
-      }
-    };
+    const enableMocking = async () => {
+      if (process.env.NEXT_PUBLIC_API_MOCKING !== 'enabled') return;
+    
+      await initMSW();
+      setIsReady(true);
+    }
 
-    if (!isReady) init();
+    if (!isReady) enableMocking();
   }, [isReady]);
 
   if (!isReady) return null;


### PR DESCRIPTION
**원인**
provider에서 await으로 초기화 함수를 기다리는데 초기화 함수에서 worker.start()를 리턴을 안해줘서 생기는 오류.
await에서 아무것도 반환할 수 없으니까 그냥 무시하고 바로 setIsReady가 실행되어 초기화함수가 완료되기전에 컴포넌트가 렌더링이 된 것임.

**해결 방법**
initMSW함수에서 worker.start()를 return해줌.