### PR TITLE
Refactor/룩북 페이지, 모달

### DIFF
--- a/src/common/consts/modal.ts
+++ b/src/common/consts/modal.ts
@@ -1,0 +1,19 @@
+export const modalState = {
+  auth: {
+    message: "사용자 인증이 해제되어 재로그인이 필요합니다.,로그인페이지로 이동할까요?",
+    btnText: "로그인하기",
+    cancelText: "둘러보기",
+  },
+  login: {
+    message: "로그인 후 이용 가능합니다.,로그인페이지로 이동할까요?",
+    btnText: "로그인하기",
+  },
+  signin: {
+    message: "유저 정보가 존재하지 않습니다.,회원가입을 진행할까요?",
+    btnText: "회원가입하기",
+  },
+  comment: {
+    message: "댓글을 삭제할까요?",
+    btnText: "삭제",
+  },
+};

--- a/src/common/consts/modal.ts
+++ b/src/common/consts/modal.ts
@@ -1,15 +1,15 @@
 export const modalState = {
   auth: {
-    message: "사용자 인증이 해제되어 재로그인이 필요합니다.,로그인페이지로 이동할까요?",
+    message: "사용자 인증이 해제되어 재로그인이 필요합니다.\n로그인페이지로 이동할까요?",
     btnText: "로그인하기",
     cancelText: "둘러보기",
   },
   login: {
-    message: "로그인 후 이용 가능합니다.,로그인페이지로 이동할까요?",
+    message: "로그인 후 이용 가능합니다.\n로그인페이지로 이동할까요?",
     btnText: "로그인하기",
   },
   signin: {
-    message: "유저 정보가 존재하지 않습니다.,회원가입을 진행할까요?",
+    message: "유저 정보가 존재하지 않습니다.\n회원가입을 진행할까요?",
     btnText: "회원가입하기",
   },
   comment: {

--- a/src/common/consts/status.ts
+++ b/src/common/consts/status.ts
@@ -1,0 +1,5 @@
+const STATUS = {
+  SUCCESS: "success",
+  ERROR: "error",
+  LOADING: "loading",
+};

--- a/src/components/common/ui/modal.tsx
+++ b/src/components/common/ui/modal.tsx
@@ -17,11 +17,7 @@ const Modal: NextPage<IModal> = ({ message, btnText, cancelText, submitFn, cance
         <>
           <div className="fixed bottom-1/2 left-1/2 z-50 w-80 -translate-x-1/2 translate-y-1/2 rounded-lg bg-black py-5 text-center text-white shadow-md">
             <div className="mb-4 px-5">
-              {message.split(",").map((text, i) => (
-                <p key={`${text}-${i}`} className="whitespace-nowrap">
-                  {text}
-                </p>
-              ))}
+              <p className="whitespace-pre-wrap">{message}</p>
             </div>
             <div className="flex w-full gap-2 px-5">
               <button

--- a/src/components/common/ui/modal.tsx
+++ b/src/components/common/ui/modal.tsx
@@ -1,42 +1,46 @@
 import { NextPage } from "next";
 import Overlay from "../overlay";
-import { ModalProps } from "./types";
+import { IModal } from "./types";
 
-interface IModal {
-  modal: ModalProps;
-  submit: () => void;
-  cancel: () => void;
-}
+const Modal: NextPage<IModal> = ({ message, btnText, cancelText, submitFn, cancelFn, isOpen }) => {
+  const handleCancel = () => {
+    if (cancelFn) cancelFn();
+  };
 
-const Modal: NextPage<IModal> = ({ modal, submit, cancel }) => {
-  const { message, btnText, cancelText } = modal;
+  const handleSubmit = () => {
+    if (submitFn) submitFn();
+  };
 
   return (
     <>
-      <div className="fixed bottom-1/2 left-1/2 z-50 w-80 translate-y-1/2 -translate-x-1/2 rounded-lg bg-black py-5 text-center text-white shadow-md">
-        <div className="mb-4 px-5">
-          {message.split(",").map((text, i) => (
-            <p key={`${text}-${i}`} className="whitespace-nowrap">
-              {text}
-            </p>
-          ))}
-        </div>
-        <div className="flex w-full gap-2 px-5">
-          <button
-            onClick={cancel}
-            className="w-1/2 cursor-pointer rounded-md bg-common-black py-3 transition hover:bg-textColor-gray-100"
-          >
-            {cancelText ? cancelText : "취소"}
-          </button>
-          <button
-            onClick={submit}
-            className="w-1/2 cursor-pointer rounded-md bg-white py-3 text-black transition hover:bg-primary-violet"
-          >
-            {btnText}
-          </button>
-        </div>
-      </div>
-      <Overlay />
+      {isOpen && (
+        <>
+          <div className="fixed bottom-1/2 left-1/2 z-50 w-80 -translate-x-1/2 translate-y-1/2 rounded-lg bg-black py-5 text-center text-white shadow-md">
+            <div className="mb-4 px-5">
+              {message.split(",").map((text, i) => (
+                <p key={`${text}-${i}`} className="whitespace-nowrap">
+                  {text}
+                </p>
+              ))}
+            </div>
+            <div className="flex w-full gap-2 px-5">
+              <button
+                onClick={handleCancel}
+                className="w-1/2 cursor-pointer rounded-md bg-common-black py-3 transition hover:bg-textColor-gray-100"
+              >
+                {cancelText ? cancelText : "취소"}
+              </button>
+              <button
+                onClick={handleSubmit}
+                className="w-1/2 cursor-pointer rounded-md bg-white py-3 text-black transition hover:bg-primary-violet"
+              >
+                {btnText}
+              </button>
+            </div>
+          </div>
+          <Overlay />
+        </>
+      )}
     </>
   );
 };

--- a/src/components/common/ui/types.ts
+++ b/src/components/common/ui/types.ts
@@ -9,3 +9,7 @@ export interface ModalProps {
 export interface setModalProps {
   ({ message, btnText, cancelFn, submitFn }: ModalProps): void;
 }
+
+export interface IModal extends ModalProps {
+  isOpen: boolean;
+}

--- a/src/components/lookbook/detail/comment-form.tsx
+++ b/src/components/lookbook/detail/comment-form.tsx
@@ -1,0 +1,26 @@
+import { useForm } from "react-hook-form";
+import { CommentFormProps } from "./types";
+import { Icon } from "@iconify/react";
+
+const CommentForm = ({ commentValue, submit, onChange }: CommentFormProps) => {
+  const { register, handleSubmit } = useForm();
+
+  return (
+    <form
+      onSubmit={handleSubmit(submit)}
+      className="fixed bottom-0 z-10 flex h-[60px] w-[390px] items-center justify-between border-t border-borderColor-gray bg-white px-5"
+    >
+      <input
+        type="text"
+        placeholder="댓글을 입력해주세요."
+        value={commentValue}
+        {...register("comment", {
+          onChange: e => onChange(e.target.value),
+        })}
+      />
+      <Icon icon="tabler:mood-smile" className="cursor-pointer text-xl text-textColor-gray-100" />
+    </form>
+  );
+};
+
+export default CommentForm;

--- a/src/components/lookbook/detail/comment-list.tsx
+++ b/src/components/lookbook/detail/comment-list.tsx
@@ -18,8 +18,8 @@ const CommentList = ({ userData, comment, updateComment, deleteComment }: Commen
             </div>
             {author.nickname == currentUserNickname && (
               <div className="flex gap-3 text-textColor-gray-100">
-                <button onClick={() => updateComment(id, text)}>수정</button>
-                <button onClick={() => deleteComment(id)}>삭제</button>
+                <button onClick={() => updateComment({ commentId: id, text })}>수정</button>
+                <button onClick={() => deleteComment({ commentId: id, userId: userData?.id })}>삭제</button>
               </div>
             )}
           </li>

--- a/src/components/lookbook/detail/comment-list.tsx
+++ b/src/components/lookbook/detail/comment-list.tsx
@@ -1,0 +1,32 @@
+import { CommentListProps } from "./types";
+
+const CommentList = ({ userData, comment, updateComment, deleteComment }: CommentListProps) => {
+  const currentUserNickname = userData ? userData.nickname : "";
+
+  return (
+    <div className="py-4">
+      <div>
+        <h2 className="mr-2 inline-block text-lg">comments</h2>
+        <span className="text-base font-bold">{comment?.length}</span>
+      </div>
+      <ul className="mt-3">
+        {comment?.map(({ id, author, text }, i) => (
+          <li key={`코멘트${i}`} className="flex justify-between">
+            <div className="flex gap-3">
+              <b className="text-base font-bold">{author.nickname}</b>
+              {text}
+            </div>
+            {author.nickname == currentUserNickname && (
+              <div className="flex gap-3 text-textColor-gray-100">
+                <button onClick={() => updateComment(id, text)}>수정</button>
+                <button onClick={() => deleteComment(id)}>삭제</button>
+              </div>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default CommentList;

--- a/src/components/lookbook/detail/contents-box.tsx
+++ b/src/components/lookbook/detail/contents-box.tsx
@@ -1,19 +1,29 @@
-import { Icon } from "@iconify/react";
 import { NextPage } from "next";
+import { useRouter } from "next/router";
+
+import { Icon } from "@iconify/react";
+
 import useFavorite from "src/hooks/useFavorite";
+import useModal from "src/hooks/useModal";
 import { ContentsBoxProps } from "./types";
 
 const ContentsBox: NextPage<ContentsBoxProps> = ({ userId, lookbookData, setInput, setShowComment }) => {
   const { id, description, hashTag, comment } = lookbookData;
+
+  const router = useRouter();
+
+  const goLoginPage = () => router.push("/login");
 
   const { isFavoriteActive, favoriteCount, toggleFavoriteButton } = useFavorite({
     currentUserId: userId,
     lookbookData,
   });
 
+  const { setLoginModal } = useModal();
+
   const clickComment = () => {
     if (!userId) {
-      // setModal();
+      setLoginModal({ submitFn: goLoginPage });
       return;
     }
 
@@ -22,7 +32,7 @@ const ContentsBox: NextPage<ContentsBoxProps> = ({ userId, lookbookData, setInpu
 
   const clickFavoriteButton = async () => {
     if (!userId) {
-      // setModal();
+      setLoginModal({ submitFn: goLoginPage });
       return;
     }
 

--- a/src/components/lookbook/detail/contents-box.tsx
+++ b/src/components/lookbook/detail/contents-box.tsx
@@ -1,0 +1,65 @@
+import { Icon } from "@iconify/react";
+import { NextPage } from "next";
+import useFavorite from "src/hooks/useFavorite";
+import { ContentsBoxProps } from "./types";
+
+const ContentsBox: NextPage<ContentsBoxProps> = ({ userId, lookbookData, setInput, setShowComment }) => {
+  const { id, description, hashTag, comment } = lookbookData;
+
+  const { isFavoriteActive, favoriteCount, toggleFavoriteButton } = useFavorite({
+    currentUserId: userId,
+    lookbookData,
+  });
+
+  const clickComment = () => {
+    if (!userId) {
+      // setModal();
+      return;
+    }
+
+    setInput(id);
+  };
+
+  const clickFavoriteButton = async () => {
+    if (!userId) {
+      // setModal();
+      return;
+    }
+
+    toggleFavoriteButton();
+  };
+
+  return (
+    <>
+      <div>
+        <div className="mb-3 flex gap-2 text-xs text-common-gray">
+          <div>2023.03.11</div>
+          <div>좋아요 {favoriteCount}</div>
+        </div>
+        {(description || hashTag[0]?.tag !== "") && (
+          <p className="mb-2">
+            {description && <span className="mr-2">{description}</span>}
+            {hashTag?.map(({ tag }, i) => (
+              <span key={`태그${i}`} className="mr-1">
+                {tag !== "" && `#${tag}`}
+              </span>
+            ))}
+          </p>
+        )}
+        <span className="cursor-pointer text-common-gray hover:underline" onClick={() => setShowComment(true)}>
+          댓글 {comment ? comment.length : 0}개
+        </span>
+      </div>
+      <div className="absolute right-4 top-4 flex items-center gap-3 text-2xl [&>svg]:cursor-pointer">
+        <Icon icon="ci:chat-circle" onClick={clickComment} />
+        {isFavoriteActive ? (
+          <Icon icon="icon-park-solid:like" color="#ff5252" onClick={clickFavoriteButton} />
+        ) : (
+          <Icon icon="icon-park-outline:like" onClick={clickFavoriteButton} />
+        )}
+      </div>
+    </>
+  );
+};
+
+export default ContentsBox;

--- a/src/components/lookbook/detail/post-item.tsx
+++ b/src/components/lookbook/detail/post-item.tsx
@@ -1,97 +1,28 @@
-import { useEffect, useState } from "react";
 import { NextPage } from "next";
-import { Icon } from "@iconify/react";
-import { useMutation } from "react-query";
-import useFavorite from "../../../hooks/useFavorite";
-import { LookbookData, UserData } from "../../../common/types/data.types";
+import { useState } from "react";
+
 import ImageSlide from "../../market/detail/image-slide";
 import TagItem from "./tag-item";
 
-interface PostItemProps extends LookbookData {
-  userData: UserData;
-  setInput: (postId: number, val?: boolean) => void;
-  updateComment: (commentId: number, text: string) => void;
-  deleteComment: (commentId: number) => void;
-  isModal?: boolean;
-  modal: React.ComponentType | JSX.Element;
-  setModal: () => void;
-}
+import { PostItemProps } from "./types";
+import CommentList from "./comment-list";
+import ContentsBox from "./contents-box";
 
-const PostItem: NextPage<PostItemProps> = ({
-  userData,
-  id,
-  user,
-  imgurl,
-  favorite,
-  description,
-  hashTag,
-  product,
-  comment = [],
-  updateComment,
-  deleteComment,
-  isModal,
-  setInput,
-  modal,
-  setModal,
-}) => {
-  const currentUserNickname = userData ? userData.nickname : "";
-  const currentUserId = userData ? userData.id : 0;
-  const {
-    isFavoriteActive,
-    favoriteCount,
-    updateFavorite,
-    changeCount,
-    changeButtonSytle,
-    updateFavoriteCount,
-    initialButtonStyle,
-  } = useFavorite(currentUserId);
-
+const PostItem: NextPage<PostItemProps> = props => {
   const [showComment, setShowComment] = useState<boolean>(false);
 
-  const isVisbileComment = showComment && comment.length > 0;
+  const { userData, lookbookData, updateComment, deleteComment, isModal, setInput, modal } = props;
 
-  const { mutate } = useMutation(updateFavorite, {
-    onSuccess: ({ data }) => {
-      changeCount();
-    },
-    onError: ({ response }) => {
-      console.log(response.data.message);
-    },
-  });
+  const { user, imgurl, comment, product } = lookbookData;
 
-  const clickComment = () => {
-    if (!currentUserId) {
-      setModal();
-      return;
-    }
-    setInput(id, true);
-  };
-
-  const toggleFavoriteButton = async () => {
-    if (currentUserId === 0) {
-      setModal();
-      return;
-    }
-    changeButtonSytle();
-    mutate({ currentUserId, lookId: id });
-  };
-
-  useEffect(() => {
-    if (!favorite) return;
-    updateFavoriteCount(favorite.length);
-    initialButtonStyle(favorite);
-  }, [favorite]);
+  const hasComment = comment && comment.length > 0;
 
   return (
     <>
       {isModal && modal}
       <div className="flex items-center justify-between px-5 py-3">
         <div className="flex items-center">
-          <img
-            src={user.profileImg}
-            alt=""
-            className="mr-3 h-10 w-10 rounded-full border-2 border-common-black"
-          />
+          <img src={user.profileImg} alt="" className="mr-3 h-10 w-10 rounded-full border-2 border-common-black" />
           <div>
             <p className="text-sm font-bold">{user.nickname}</p>
           </div>
@@ -99,68 +30,19 @@ const PostItem: NextPage<PostItemProps> = ({
       </div>
       <ImageSlide images={imgurl} />
       <div className="relative p-5">
-        <div>
-          <div className="mb-3 flex gap-2 text-xs text-common-gray">
-            <div>2023.03.11</div>
-            <div>좋아요 {favoriteCount}</div>
-          </div>
-          {(description || hashTag[0]?.tag !== "") && (
-            <p className="mb-2">
-              {description && <span className="mr-2">{description}</span>}
-              {hashTag?.map(({ tag }, i) => (
-                <span key={`태그${i}`} className="mr-1">
-                  {tag !== "" && `#${tag}`}
-                </span>
-              ))}
-            </p>
-          )}
-          <span
-            className="cursor-pointer text-common-gray hover:underline"
-            onClick={() => setShowComment(true)}
-          >
-            댓글 {comment ? comment.length : 0}개
-          </span>
-        </div>
-        <div className="absolute right-4 top-4 flex items-center gap-3 text-2xl [&>svg]:cursor-pointer">
-          <Icon icon="ci:chat-circle" onClick={clickComment} />
-          {isFavoriteActive ? (
-            <Icon
-              icon="icon-park-solid:like"
-              color="#ff5252"
-              onClick={toggleFavoriteButton}
-            />
-          ) : (
-            <Icon
-              icon="icon-park-outline:like"
-              onClick={toggleFavoriteButton}
-            />
-          )}
-        </div>
-        {isVisbileComment && (
-          <div className="py-4">
-            <div>
-              <h2 className="mr-2 inline-block text-lg">comments</h2>
-              <span className="text-base font-bold">{comment?.length}</span>
-            </div>
-            <ul className="mt-3">
-              {comment?.map(({ id, author, text }, i) => (
-                <li key={`코멘트${i}`} className="flex justify-between">
-                  <div className="flex gap-3">
-                    <b className="text-base font-bold">{author.nickname}</b>
-                    {text}
-                  </div>
-                  {author.nickname == currentUserNickname && (
-                    <div className="flex gap-3 text-textColor-gray-100">
-                      <button onClick={() => updateComment(id, text)}>
-                        수정
-                      </button>
-                      <button onClick={() => deleteComment(id)}>삭제</button>
-                    </div>
-                  )}
-                </li>
-              ))}
-            </ul>
-          </div>
+        <ContentsBox
+          userId={userData?.id}
+          lookbookData={lookbookData}
+          setInput={setInput}
+          setShowComment={setShowComment}
+        />
+        {showComment && hasComment && (
+          <CommentList
+            userData={userData}
+            comment={comment}
+            updateComment={updateComment}
+            deleteComment={deleteComment}
+          />
         )}
         {product.length > 0 && (
           <div className="mt-3 border-t border-borderColor-gray">

--- a/src/components/lookbook/detail/post-item.tsx
+++ b/src/components/lookbook/detail/post-item.tsx
@@ -31,7 +31,7 @@ const PostItem: NextPage<PostItemProps> = props => {
       <ImageSlide images={imgurl} />
       <div className="relative p-5">
         <ContentsBox
-          userId={userData?.id}
+          userId={userData?.id ?? 1}
           lookbookData={lookbookData}
           setInput={setInput}
           setShowComment={setShowComment}

--- a/src/components/lookbook/detail/post-item.tsx
+++ b/src/components/lookbook/detail/post-item.tsx
@@ -1,25 +1,29 @@
 import { NextPage } from "next";
-import { useState } from "react";
+import { useContext, useState } from "react";
 
 import ImageSlide from "../../market/detail/image-slide";
 import TagItem from "./tag-item";
-
-import { PostItemProps } from "./types";
+import Modal from "src/components/common/ui/modal";
 import CommentList from "./comment-list";
 import ContentsBox from "./contents-box";
+
+import { modalContext } from "src/context/modal-context";
+import { PostItemProps } from "./types";
 
 const PostItem: NextPage<PostItemProps> = props => {
   const [showComment, setShowComment] = useState<boolean>(false);
 
-  const { userData, lookbookData, updateComment, deleteComment, isModal, setInput, modal } = props;
+  const { userData, lookbookData, updateComment, deleteComment, setInput } = props;
 
   const { user, imgurl, comment, product } = lookbookData;
 
   const hasComment = comment && comment.length > 0;
 
+  const { isOpen, modal } = useContext(modalContext);
+
   return (
     <>
-      {isModal && modal}
+      <Modal {...modal} isOpen={isOpen} />
       <div className="flex items-center justify-between px-5 py-3">
         <div className="flex items-center">
           <img src={user.profileImg} alt="" className="mr-3 h-10 w-10 rounded-full border-2 border-common-black" />

--- a/src/components/lookbook/detail/tag-item.tsx
+++ b/src/components/lookbook/detail/tag-item.tsx
@@ -1,6 +1,6 @@
 import { NextPage } from "next";
 import Link from "next/link";
-import React from "react";
+
 import { ProductDataMin } from "../../../common/types/data.types";
 import { priceAddComma } from "../../../common/util/markets";
 
@@ -8,10 +8,7 @@ const TagItem: NextPage<ProductDataMin[]> = product => {
   return (
     <>
       {Object.values(product).map(({ id, imgurl, title, brand, price }) => (
-        <li
-          key={id}
-          className="flex min-w-[200px] items-center justify-between"
-        >
+        <li key={id} className="flex min-w-[200px] items-center justify-between">
           <Link href={`/market/${id}`} className="flex">
             <img
               src={imgurl[0]?.img}
@@ -20,9 +17,7 @@ const TagItem: NextPage<ProductDataMin[]> = product => {
             />
             <div className="text-common-black">
               <p className="text-sm">{brand}</p>
-              <p className="mb-2 w-32 truncate text-xs text-textColor-gray-100">
-                {title}
-              </p>
+              <p className="mb-2 w-32 truncate text-xs text-textColor-gray-100">{title}</p>
               <p className="font-bold">{priceAddComma(price)}</p>
             </div>
           </Link>

--- a/src/components/lookbook/detail/types.ts
+++ b/src/components/lookbook/detail/types.ts
@@ -19,19 +19,16 @@ interface Comment {
 export interface CommentListProps {
   userData: UserData;
   comment: Comment[] | undefined;
-  updateComment: (commentId: number, text: string) => void;
-  deleteComment: (commentId: number) => void;
+  updateComment: ({ commentId, text }: { commentId: number; text: string }) => void;
+  deleteComment: ({ commentId, userId }: { commentId: number; userId: number }) => void;
 }
 
 export interface PostItemProps {
   userData: UserData;
   lookbookData: LookbookData;
   setInput: (postId: number) => void;
-  updateComment: (commentId: number, text: string) => void;
-  deleteComment: (commentId: number) => void;
-  modal: React.ComponentType | JSX.Element;
-  setModal: () => void;
-  isModal?: boolean;
+  updateComment: ({ commentId, text }: { commentId: number; text: string }) => void;
+  deleteComment: ({ commentId, userId }: { commentId: number; userId: number }) => void;
 }
 
 export interface ContentsBoxProps {

--- a/src/components/lookbook/detail/types.ts
+++ b/src/components/lookbook/detail/types.ts
@@ -1,0 +1,42 @@
+import { Dispatch, SetStateAction } from "react";
+import { FieldValues } from "react-hook-form";
+import { LookbookData, UserData } from "src/common/types/data.types";
+
+export interface CommentFormProps {
+  commentValue: string;
+  submit: (data: FieldValues) => void;
+  onChange: Dispatch<SetStateAction<string>>;
+}
+
+interface Comment {
+  id: number;
+  text: string;
+  author: {
+    nickname: string;
+  };
+}
+
+export interface CommentListProps {
+  userData: UserData;
+  comment: Comment[] | undefined;
+  updateComment: (commentId: number, text: string) => void;
+  deleteComment: (commentId: number) => void;
+}
+
+export interface PostItemProps {
+  userData: UserData;
+  lookbookData: LookbookData;
+  setInput: (postId: number) => void;
+  updateComment: (commentId: number, text: string) => void;
+  deleteComment: (commentId: number) => void;
+  modal: React.ComponentType | JSX.Element;
+  setModal: () => void;
+  isModal?: boolean;
+}
+
+export interface ContentsBoxProps {
+  userId: number;
+  lookbookData: LookbookData;
+  setInput: (postId: number) => void;
+  setShowComment: Dispatch<SetStateAction<boolean>>;
+}

--- a/src/components/lookbook/look-item.tsx
+++ b/src/components/lookbook/look-item.tsx
@@ -1,4 +1,5 @@
 import { NextPage } from "next";
+import { useRouter } from "next/router";
 import Image from "next/image";
 import Link from "next/link";
 
@@ -6,18 +7,24 @@ import { Icon } from "@iconify/react";
 
 import useFavorite from "../../hooks/useFavorite";
 import { LookbookData } from "../../common/types/data.types";
+import useModal from "src/hooks/useModal";
 
 interface LookItemProps extends LookbookData {
   userId: number;
-  setModal: () => void;
 }
 
-const LookItem: NextPage<LookItemProps> = ({ user, imgurl, id, userId, setModal }) => {
+const LookItem: NextPage<LookItemProps> = ({ user, imgurl, id, userId }) => {
   const { isFavoriteActive, toggleFavoriteButton } = useFavorite({ currentUserId: userId || 1 });
+
+  const { setLoginModal } = useModal();
+
+  const router = useRouter();
+
+  const goLoginPage = () => router.push("/login");
 
   const clickFavoriteButton = async () => {
     if (!userId && userId !== 0) {
-      setModal();
+      setLoginModal({ submitFn: goLoginPage });
       return;
     }
 

--- a/src/components/lookbook/look-item.tsx
+++ b/src/components/lookbook/look-item.tsx
@@ -1,9 +1,9 @@
-import { Icon } from "@iconify/react";
 import { NextPage } from "next";
 import Image from "next/image";
 import Link from "next/link";
-import { useEffect } from "react";
-import { useMutation } from "react-query";
+
+import { Icon } from "@iconify/react";
+
 import useFavorite from "../../hooks/useFavorite";
 import { LookbookData } from "../../common/types/data.types";
 
@@ -12,43 +12,17 @@ interface LookItemProps extends LookbookData {
   setModal: () => void;
 }
 
-const LookItem: NextPage<LookItemProps> = ({
-  user,
-  imgurl,
-  id,
-  favorite,
-  userId,
-  setModal,
-}) => {
-  const {
-    isFavoriteActive,
-    updateFavorite,
-    changeButtonSytle,
-    initialButtonStyle,
-  } = useFavorite(userId);
+const LookItem: NextPage<LookItemProps> = ({ user, imgurl, id, userId, setModal }) => {
+  const { isFavoriteActive, toggleFavoriteButton } = useFavorite({ currentUserId: userId || 1 });
 
-  const { mutate } = useMutation(updateFavorite, {
-    onSuccess: ({ data }) => {
-      console.log(data.message);
-    },
-    onError: ({ response }) => {
-      console.log(response.data.message);
-    },
-  });
-
-  const toggleFavoriteButton = async () => {
-    if (userId === 0) {
+  const clickFavoriteButton = async () => {
+    if (!userId && userId !== 0) {
       setModal();
       return;
     }
-    changeButtonSytle();
-    mutate({ currentUserId: userId, lookId: id });
-  };
 
-  useEffect(() => {
-    if (!favorite) return;
-    initialButtonStyle(favorite);
-  }, [favorite]);
+    toggleFavoriteButton();
+  };
 
   return (
     <li className="flex h-[220px] justify-center border-b border-r border-common-black pt-4">
@@ -73,14 +47,14 @@ const LookItem: NextPage<LookItemProps> = ({
                 icon="icon-park-solid:like"
                 color="#ff5252"
                 className="border border-common-black text-lg"
-                onClick={toggleFavoriteButton}
+                onClick={clickFavoriteButton}
               />
             </div>
           ) : (
             <Icon
               icon="icon-park-outline:like"
               className="cursor-pointer text-lg transition hover:scale-110"
-              onClick={toggleFavoriteButton}
+              onClick={clickFavoriteButton}
             />
           )}
         </div>

--- a/src/components/market/detail/image-slide.tsx
+++ b/src/components/market/detail/image-slide.tsx
@@ -1,43 +1,27 @@
-import { Icon } from "@iconify/react";
 import { NextPage } from "next";
+import { Icon } from "@iconify/react";
 import Image from "next/image";
+
+import LoadingSpinner from "../../common/ui/loading-spinner";
+
+import useSlide from "../../../hooks/useSlide";
 import { translateClasses } from "../../../common/consts/translate-class";
 import { cls } from "../../../common/util/class";
-import LoadingSpinner from "../../common/ui/loading-spinner";
-import useSlide from "../../../hooks/useSlide";
+import { ImageSlideProps } from "./types";
 
-interface Images {
-  id: number;
-  img: string;
-  productId?: number;
-  imgH?: string;
-  propH?: number;
-}
-
-const ImageSlide: NextPage<{
-  images: Images[];
-  isLoading?: boolean;
-  imgH?: string;
-  propH?: number;
-  slideTime?: number;
-}> = ({ images, isLoading, imgH, propH, slideTime }) => {
-  const { next, prev, transitionEnd, translateX, isMoving, slideNum } =
-    useSlide({
-      list: images,
-      classes: translateClasses.detailSlide,
-      slideTime: slideTime,
-    });
+const ImageSlide: NextPage<ImageSlideProps> = ({ images, isLoading, imgH, propH, slideTime }) => {
+  const { next, prev, transitionEnd, translateX, isMoving, slideNum } = useSlide({
+    list: images,
+    classes: translateClasses.detailSlide,
+    slideTime: slideTime,
+  });
 
   const lastImageClone = images[images.length - 1]?.img as string;
   const firstImageClone = images[0]?.img as string;
 
   return (
     <div className="relative">
-      <div
-        className={`${
-          imgH ? imgH : "min-h-[370px]"
-        } w-full overflow-hidden bg-slate-200`}
-      >
+      <div className={`${imgH ? imgH : "min-h-[370px]"} w-full overflow-hidden bg-slate-200`}>
         {isLoading && <LoadingSpinner />}
         <ul
           className={cls(
@@ -63,9 +47,7 @@ const ImageSlide: NextPage<{
                 alt={`상품이미지${item.id}`}
                 width={390}
                 height={propH ? propH : 370}
-                className={`${
-                  imgH ? imgH : "h-[370px]"
-                } w-[390px] object-cover`}
+                className={`${imgH ? imgH : "h-[370px]"} w-[390px] object-cover`}
               />
             </li>
           ))}
@@ -82,16 +64,8 @@ const ImageSlide: NextPage<{
       </div>
       {images.length > 1 && (
         <div className="absolute top-1/2 flex w-[390px] items-center justify-between px-5 text-2xl text-common-black">
-          <Icon
-            icon="material-symbols:chevron-left"
-            className="absolute left-2"
-            onClick={prev}
-          />
-          <Icon
-            icon="material-symbols:chevron-right"
-            className="absolute right-2"
-            onClick={next}
-          />
+          <Icon icon="material-symbols:chevron-left" className="absolute left-2" onClick={prev} />
+          <Icon icon="material-symbols:chevron-right" className="absolute right-2" onClick={next} />
         </div>
       )}
       <div className="absolute bottom-2 flex h-[3px] w-[390px] justify-center space-x-0.5">
@@ -99,9 +73,7 @@ const ImageSlide: NextPage<{
           images.map((item, i) => (
             <span
               key={item.id}
-              className={`block h-[2px] w-6 ${
-                slideNum - 1 === i ? "bg-black" : "bg-white opacity-50"
-              }`}
+              className={`block h-[2px] w-6 ${slideNum - 1 === i ? "bg-black" : "bg-white opacity-50"}`}
             />
           ))}
       </div>

--- a/src/components/market/detail/types.ts
+++ b/src/components/market/detail/types.ts
@@ -10,3 +10,19 @@ export interface CategoryBoxProps {
   product: ProductData;
   favoriteCount: number;
 }
+
+export interface Images {
+  id: number;
+  img: string;
+  productId?: number;
+  imgH?: string;
+  propH?: number;
+}
+
+export interface ImageSlideProps {
+  images: Images[];
+  isLoading?: boolean;
+  imgH?: string;
+  propH?: number;
+  slideTime?: number;
+}

--- a/src/context/modal-context.tsx
+++ b/src/context/modal-context.tsx
@@ -1,39 +1,46 @@
-import React, { createContext, useState } from "react";
+import { createContext, useEffect, useState } from "react";
+import { ModalProps } from "src/components/common/ui/types";
 
-import { ModalProps } from "../common/types/modal-type";
+interface ModalContext {
+  isOpen: boolean;
+  modal: ModalProps;
+  cancel: () => void;
+  submit: () => void;
+  setModalState: (props: ModalProps) => void;
+  openModal: (status: boolean) => void;
+}
 
-export const modalContext = createContext({
-  show: false,
-  modal: {},
-  cancel: () => {},
-  submit: () => {},
-  setModalState: (props: ModalProps) => {},
-  openModal: (status: boolean) => {},
-});
-
-const ModalContextProvider = ({ children }: { children: React.ReactNode }) => {
-  const [show, setShow] = useState<boolean>(false);
-  const [modal, setModal] = useState<ModalProps>({
+export const modalContext = createContext<ModalContext>({
+  isOpen: false,
+  modal: {
     message: "",
     btnText: "",
     cancelText: "",
     cancelFn: null,
     submitFn: null,
+  },
+  cancel: () => {},
+  submit: () => {},
+  setModalState: () => {},
+  openModal: () => {},
+});
+
+const ModalContextProvider = ({ children }: { children: React.ReactNode }) => {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+  const [modal, setModal] = useState<ModalProps>({
+    message: "",
+    btnText: "",
+    cancelText: "취소",
+    cancelFn: null,
+    submitFn: null,
   });
 
-  const openModal = () => setShow(true);
+  const openModal = () => setIsOpen(true);
 
-  const closeModal = () => setShow(false);
+  const closeModal = () => setIsOpen(false);
 
-  const setModalState = ({
-    message,
-    btnText,
-    cancelText,
-    cancelFn,
-    submitFn,
-  }: ModalProps) => {
+  const setModalState = ({ message, btnText, cancelText, cancelFn, submitFn }: ModalProps) => {
     setModal({ message, btnText, cancelText, cancelFn, submitFn });
-    openModal();
   };
 
   const cancel = () => {
@@ -46,8 +53,12 @@ const ModalContextProvider = ({ children }: { children: React.ReactNode }) => {
     closeModal();
   };
 
+  useEffect(() => {
+    openModal();
+  }, [modal]);
+
   const value = {
-    show,
+    isOpen,
     modal,
     cancel,
     submit,
@@ -55,9 +66,7 @@ const ModalContextProvider = ({ children }: { children: React.ReactNode }) => {
     openModal,
   };
 
-  return (
-    <modalContext.Provider value={value}>{children}</modalContext.Provider>
-  );
+  return <modalContext.Provider value={value}>{children}</modalContext.Provider>;
 };
 
 export default ModalContextProvider;

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -9,7 +9,7 @@ import { isCookie, setCookie } from "../common/util/cookie";
 const useAuth = () => {
   const { data: userEmail, status: session } = useSession();
 
-  const { setAuthModalState } = useModal();
+  const { setAuthModal } = useModal();
 
   const {
     data,
@@ -30,7 +30,7 @@ const useAuth = () => {
       const visitor = isCookie("panda_visitor"); // 쿠키 확인 ~> panda_visitor
       if (!visitor) {
         console.log("사용자 인증 오류!");
-        setAuthModalState({ cancel: setCookie });
+        setAuthModal({ cancelFn: setCookie });
         return;
       }
       console.log("유효한 방문자");

--- a/src/hooks/useComment.tsx
+++ b/src/hooks/useComment.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { useCreateComment, useDeleteComment } from "src/service/query/comment";
+import useModal from "./useModal";
 
 const useComment = () => {
   const [showInput, setShowInput] = useState<boolean>(false);
@@ -10,6 +11,8 @@ const useComment = () => {
   const { mutate: createCommentMutate, status: createCommentStatus } = useCreateComment({ postId });
 
   const { mutate: deleteCommentMutate, status: deleteCommentStatus } = useDeleteComment({ commentId });
+
+  const { setCommentModal } = useModal();
 
   const reset = () => {
     setCommentValue("");
@@ -22,21 +25,24 @@ const useComment = () => {
     setPostId(postId);
   };
 
-  const updateComment = (commentId: number, text: string) => {
+  const updateComment = ({ commentId, text }: { commentId: number; text: string }) => {
     setCommentId(commentId);
     setCommentValue(text);
     setShowInput(true);
   };
 
-  const deleteComment = (commentId: number) => {
+  const deleteComment = ({ commentId, userId }: { commentId: number; userId: number }) => {
     setCommentId(commentId);
-    // setCommentModalState({ cancel: reset, submit: submit });
+    const submitFn = () => {
+      deleteCommentMutate({ userId });
+    };
+    setCommentModal({ submitFn });
   };
 
   useEffect(() => {
     if (createCommentStatus === "success") reset();
     if (createCommentStatus === "error") {
-      // setCommentModalState({ cancel: reset, submit: submit });
+      // TODO: 에러확인 모달 띄우기. (확인버튼만 있는 모달 만들기)
       reset();
     }
   }, [createCommentStatus]);
@@ -44,7 +50,7 @@ const useComment = () => {
   useEffect(() => {
     if (deleteCommentStatus === "success") reset();
     if (deleteCommentStatus === "error") {
-      // setCommentModalState({ cancel: reset, submit: submit });
+      // TODO: 에러확인 모달 띄우기. (확인버튼만 있는 모달 만들기)
       reset();
     }
   }, [deleteCommentStatus]);

--- a/src/hooks/useComment.tsx
+++ b/src/hooks/useComment.tsx
@@ -1,0 +1,69 @@
+import { useEffect, useState } from "react";
+import { useCreateComment, useDeleteComment } from "src/service/query/comment";
+
+const useComment = () => {
+  const [showInput, setShowInput] = useState<boolean>(false);
+  const [commentValue, setCommentValue] = useState<string>("");
+  const [postId, setPostId] = useState<number>(0);
+  const [commentId, setCommentId] = useState<number>(0);
+
+  const { mutate: createCommentMutate, status: createCommentStatus } = useCreateComment({ postId });
+
+  const { mutate: deleteCommentMutate, status: deleteCommentStatus } = useDeleteComment({ commentId });
+
+  const reset = () => {
+    setCommentValue("");
+    setShowInput(false);
+  };
+
+  const setInput = (postId: number) => {
+    setCommentValue("");
+    setShowInput(true);
+    setPostId(postId);
+  };
+
+  const updateComment = (commentId: number, text: string) => {
+    setCommentId(commentId);
+    setCommentValue(text);
+    setShowInput(true);
+  };
+
+  const deleteComment = (commentId: number) => {
+    setCommentId(commentId);
+    // setCommentModalState({ cancel: reset, submit: submit });
+  };
+
+  useEffect(() => {
+    if (createCommentStatus === "success") reset();
+    if (createCommentStatus === "error") {
+      // setCommentModalState({ cancel: reset, submit: submit });
+      reset();
+    }
+  }, [createCommentStatus]);
+
+  useEffect(() => {
+    if (deleteCommentStatus === "success") reset();
+    if (deleteCommentStatus === "error") {
+      // setCommentModalState({ cancel: reset, submit: submit });
+      reset();
+    }
+  }, [deleteCommentStatus]);
+
+  return {
+    showInput,
+    commentValue,
+    handleComment: {
+      reset,
+      setInput,
+      onChange: setCommentValue,
+      update: updateComment,
+      delete: deleteComment,
+    },
+    mutate: {
+      createComment: createCommentMutate,
+      deleteComment: deleteCommentMutate,
+    },
+  };
+};
+
+export default useComment;

--- a/src/hooks/useComment.tsx
+++ b/src/hooks/useComment.tsx
@@ -1,9 +1,13 @@
 import { useEffect, useState } from "react";
-import { useCreateComment, useDeleteComment } from "src/service/query/comment";
 import useModal from "./useModal";
+import { useCreateComment, useDeleteComment } from "src/service/query/comment";
 
 const useComment = () => {
   const [showInput, setShowInput] = useState<boolean>(false);
+  /**
+   * TODO:
+   * react-hook-form으로 input관리
+   */
   const [commentValue, setCommentValue] = useState<string>("");
   const [postId, setPostId] = useState<number>(0);
   const [commentId, setCommentId] = useState<number>(0);
@@ -40,16 +44,16 @@ const useComment = () => {
   };
 
   useEffect(() => {
-    if (createCommentStatus === "success") reset();
-    if (createCommentStatus === "error") {
+    if (createCommentStatus === STATUS.SUCCESS) reset();
+    if (createCommentStatus === STATUS.ERROR) {
       // TODO: 에러확인 모달 띄우기. (확인버튼만 있는 모달 만들기)
       reset();
     }
   }, [createCommentStatus]);
 
   useEffect(() => {
-    if (deleteCommentStatus === "success") reset();
-    if (deleteCommentStatus === "error") {
+    if (deleteCommentStatus === STATUS.SUCCESS) reset();
+    if (deleteCommentStatus === STATUS.ERROR) {
       // TODO: 에러확인 모달 띄우기. (확인버튼만 있는 모달 만들기)
       reset();
     }

--- a/src/hooks/useFavorite.tsx
+++ b/src/hooks/useFavorite.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { useMutation } from "react-query";
 import { apiPost } from "../service/request";
-import { ProductData } from "src/common/types/data.types";
+import { LookbookData, ProductData } from "src/common/types/data.types";
 
 interface Favorite {
   id: number;
@@ -12,22 +12,19 @@ interface Favorite {
 interface useFavoriteProps {
   currentUserId: number;
   productData?: ProductData;
+  lookbookData?: LookbookData;
 }
 
-const useFavorite = ({ currentUserId, productData }: useFavoriteProps) => {
+const useFavorite = ({ currentUserId, productData, lookbookData }: useFavoriteProps) => {
   const [isFavoriteActive, setIsFavoriteActive] = useState<boolean>(false);
   const [favoriteCount, setFavoriteCount] = useState<number>(0);
 
   const updateFavorite = useCallback(
-    async (favoriteConfig: {
-      currentUserId: number;
-      lookId?: number;
-      productId?: number;
-    }) => {
+    async (favoriteConfig: { currentUserId: number; lookId?: number; productId?: number }) => {
       const { currentUserId, productId, lookId } = favoriteConfig;
       const payload = productId ? { productId } : { lookId };
 
-      const data = apiPost.UPDATE_USER(currentUserId, payload);
+      const data = apiPost.UPDATE_USER(currentUserId, payload); // 행위는 같다. (end point가 같다.)
       return data;
     },
     [],
@@ -45,18 +42,18 @@ const useFavorite = ({ currentUserId, productData }: useFavoriteProps) => {
   };
 
   const changeCount = () => {
-    isFavoriteActive
-      ? setFavoriteCount(prev => prev - 1)
-      : setFavoriteCount(prev => prev + 1);
+    isFavoriteActive ? setFavoriteCount(prev => prev - 1) : setFavoriteCount(prev => prev + 1);
   };
 
   const updateFavoriteCount = (count: number) => setFavoriteCount(count);
 
   const toggleFavoriteButton = () => {
     changeButtonSytle();
+
+    const id = productData ? "productId" : "lookId";
     mutate({
       currentUserId,
-      productId: productData?.id,
+      [id]: productData?.id ?? lookbookData?.id,
     });
   };
 
@@ -68,11 +65,19 @@ const useFavorite = ({ currentUserId, productData }: useFavoriteProps) => {
 
   useEffect(() => {
     if (!productData) return;
-    const { favorite } = productData;
+    const favorite = productData.favorite;
 
     updateFavoriteCount(favorite.length);
     initialButtonStyle(favorite);
   }, [productData]);
+
+  useEffect(() => {
+    if (!lookbookData) return;
+    const favorite = lookbookData.favorite;
+
+    updateFavoriteCount(favorite.length);
+    initialButtonStyle(favorite);
+  }, [lookbookData]);
 
   return {
     isFavoriteActive,

--- a/src/hooks/useModal.tsx
+++ b/src/hooks/useModal.tsx
@@ -1,97 +1,32 @@
-import { useRouter } from "next/router";
 import { useContext } from "react";
-
-import Modal from "../components/common/ui/modal";
-
 import { modalContext } from "../context/modal-context";
-import { ModalProps } from "../common/types/modal-type";
-import { useSession } from "next-auth/react";
+import { modalState } from "src/common/consts/modal";
 
 const useModal = () => {
-  const { show, modal, submit, cancel, setModalState } =
-    useContext(modalContext);
+  const { setModalState } = useContext(modalContext);
 
-  const { data: session } = useSession();
+  const setLoginModal = ({ submitFn, cancelFn }: { submitFn: () => void; cancelFn?: () => void }) =>
+    setModalState(Object.assign(modalState.login, { submitFn, cancelFn }));
 
-  const router = useRouter();
+  const setSigninModal = ({ submitFn, cancelFn }: { submitFn: () => void; cancelFn?: () => void }) =>
+    setModalState(Object.assign(modalState.signin, { submitFn, cancelFn }));
 
-  const goLoginPage = () => router.push("/login");
-
-  const goSigninPage = () => {
-    router.push(
-      {
-        pathname: "/signtag",
-        query: {
-          email: session?.user?.email,
-        },
-      },
-      "/signtag",
-    );
-  };
-
-  const modalState = {
-    auth: {
-      message:
-        "사용자 인증이 해제되어 재로그인이 필요합니다.,로그인페이지로 이동할까요?",
-      btnText: "로그인하기",
-      cancelText: "둘러보기",
-      submitFn: goLoginPage,
-    },
-    login: {
-      message: "로그인 후 이용 가능합니다.,로그인페이지로 이동할까요?",
-      btnText: "로그인하기",
-      submitFn: goLoginPage,
-    },
-    signin: {
-      message: "유저 정보가 존재하지 않습니다.,회원가입을 진행할까요?",
-      btnText: "회원가입하기",
-      submitFn: goSigninPage,
-    },
-    comment: {
-      message: "댓글을 삭제할까요?",
-      btnText: "삭제",
-    },
-  };
-
-  const setLoginModalState = () => setModalState(modalState.login);
-  const setSigninModalState = () => setModalState(modalState.signin);
-  const setAuthModalState = (fn: {
-    cancel: (name: string, val: any, time: number) => void;
-  }) => {
-    const newModalState = Object.assign(
-      { cancelFn: () => fn.cancel("panda_visitor", true, 3) },
-      modalState.auth,
-    );
-    setModalState(newModalState);
-  };
-  const setCommentModalState = (fn: {
-    cancel: () => void;
-    submit: (data: any) => void;
-  }) => {
-    const newModalState = Object.assign(
-      { cancelFn: fn.cancel, submitFn: fn.submit },
-      modalState.comment,
-    );
+  const setAuthModal = ({ cancelFn }: { cancelFn: (name: string, val: any, time: number) => void }) => {
+    const newModalState = Object.assign(modalState.auth, { cancelFn: () => cancelFn("panda_visitor", true, 3) });
     setModalState(newModalState);
   };
 
-  const ModalUI = () => {
-    return (
-      <>
-        {show && (
-          <Modal modal={modal as ModalProps} submit={submit} cancel={cancel} />
-        )}
-      </>
-    );
+  const setCommentModal = ({ submitFn, cancelFn }: { submitFn: () => void; cancelFn?: () => void }) => {
+    const newModalState = Object.assign(modalState.comment, { submitFn, cancelFn });
+    setModalState(newModalState);
   };
 
   return {
-    ModalUI,
-    setModalState,
-    setAuthModalState,
-    setLoginModalState,
-    setSigninModalState,
-    setCommentModalState,
+    setModal: setModalState,
+    setAuthModal,
+    setLoginModal,
+    setSigninModal,
+    setCommentModal,
   };
 };
 

--- a/src/hooks/useModal.tsx
+++ b/src/hooks/useModal.tsx
@@ -2,13 +2,18 @@ import { useContext } from "react";
 import { modalContext } from "../context/modal-context";
 import { modalState } from "src/common/consts/modal";
 
+interface SetModalProps {
+  submitFn: () => void;
+  cancelFn?: () => void;
+}
+
 const useModal = () => {
   const { setModalState } = useContext(modalContext);
 
-  const setLoginModal = ({ submitFn, cancelFn }: { submitFn: () => void; cancelFn?: () => void }) =>
+  const setLoginModal = ({ submitFn, cancelFn }: SetModalProps) =>
     setModalState(Object.assign(modalState.login, { submitFn, cancelFn }));
 
-  const setSigninModal = ({ submitFn, cancelFn }: { submitFn: () => void; cancelFn?: () => void }) =>
+  const setSigninModal = ({ submitFn, cancelFn }: SetModalProps) =>
     setModalState(Object.assign(modalState.signin, { submitFn, cancelFn }));
 
   const setAuthModal = ({ cancelFn }: { cancelFn: (name: string, val: any, time: number) => void }) => {
@@ -16,7 +21,7 @@ const useModal = () => {
     setModalState(newModalState);
   };
 
-  const setCommentModal = ({ submitFn, cancelFn }: { submitFn: () => void; cancelFn?: () => void }) => {
+  const setCommentModal = ({ submitFn, cancelFn }: SetModalProps) => {
     const newModalState = Object.assign(modalState.comment, { submitFn, cancelFn });
     setModalState(newModalState);
   };

--- a/src/pages/error-boundary.tsx
+++ b/src/pages/error-boundary.tsx
@@ -1,7 +1,6 @@
 import Error from "next/error";
-import React, { ErrorInfo, ReactNode } from "react";
-
-import { setModalProps } from "../common/types/modal-type";
+import { Component, ErrorInfo, ReactNode } from "react";
+import { setModalProps } from "src/components/common/ui/types";
 
 interface Props {
   children: ReactNode;
@@ -15,7 +14,7 @@ interface State {
   axiosError: boolean;
 }
 
-class ErrorBoundary extends React.Component<Props, State> {
+class ErrorBoundary extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -9,21 +9,28 @@ import FloatingButton from "../components/common/ui/floating-button";
 import ImageSlide from "../components/market/detail/image-slide";
 import Recommend from "../components/main/recommend";
 import ErrorBoundary from "./error-boundary";
+import { useContext } from "react";
+import { modalContext } from "src/context/modal-context";
 
-import { bannerImages } from "../common/consts/banner";
+import Modal from "src/components/common/ui/modal";
+
 import useAuth from "../hooks/useAuth";
-import useModal from "../hooks/useModal";
+import useModal from "src/hooks/useModal";
+import { bannerImages } from "../common/consts/banner";
 
 const Home: NextPage = () => {
   const { userData } = useAuth();
-  const { ModalUI, setModalState } = useModal();
+
+  const { isOpen, modal } = useContext(modalContext);
+
+  const { setModal } = useModal();
 
   return (
     <>
       <Header />
-      <ModalUI />
+      <Modal isOpen={isOpen} {...modal} />
       <ImageSlide images={bannerImages} imgH="h-72" propH={288} slideTime={5500} />
-      <ErrorBoundary errorFallback={<p>something went wrong...</p>} setModal={setModalState}>
+      <ErrorBoundary errorFallback={<p>something went wrong...</p>} setModal={setModal}>
         <div className="space-y-10 py-10">
           <Recommend userData={userData} />
           <RecentStyle />

--- a/src/pages/lookbook/[id].tsx
+++ b/src/pages/lookbook/[id].tsx
@@ -12,7 +12,6 @@ import LoadingSpinner from "../../components/common/ui/loading-spinner";
 import PostItem from "../../components/lookbook/detail/post-item";
 import CommentForm from "src/components/lookbook/detail/comment-form";
 
-import useModal from "../../hooks/useModal";
 import useComment from "src/hooks/useComment";
 import { LookbookData } from "../../common/types/data.types";
 import { useGetLookBookList, useGetLookBookPost } from "src/service/query/lookbook";
@@ -27,18 +26,11 @@ const Post: NextPage = () => {
 
   const { ref, inView } = useInView();
 
-  const { ModalUI, setLoginModalState } = useModal();
-
   const { commentValue, showInput, handleComment, mutate } = useComment();
 
   const submit = async (data: FieldValues) => {
-    if (!data.comment) {
-      const payload = { userId: userContents?.id ?? 1 };
-      mutate.deleteComment(payload);
-      return;
-    }
-
     if (data.comment.trim === "") return;
+
     const payload = { userId: userContents?.id ?? 1, comment: data.comment };
     mutate.createComment(payload);
   };
@@ -67,9 +59,6 @@ const Post: NextPage = () => {
           <PostItem
             userData={userContents}
             lookbookData={postData}
-            // isModal={show}
-            modal={<ModalUI />}
-            setModal={setLoginModalState}
             setInput={handleComment.setInput}
             updateComment={handleComment.update}
             deleteComment={handleComment.delete}
@@ -83,9 +72,6 @@ const Post: NextPage = () => {
                   key={look.id}
                   userData={userContents}
                   lookbookData={look}
-                  // isModal={show}
-                  modal={<ModalUI />}
-                  setModal={setLoginModalState}
                   setInput={handleComment.setInput}
                   updateComment={handleComment.update}
                   deleteComment={handleComment.delete}

--- a/src/pages/lookbook/index.tsx
+++ b/src/pages/lookbook/index.tsx
@@ -17,42 +17,33 @@ import { LookbookData } from "../../common/types/data.types";
 
 const Lookbook: NextPage = () => {
   const userInfo = useRecoilValueLoadable(currentUserInfoQuery);
-  const { state, contents: userContents } = userInfo;
-  const [userId, setUserId] = useState<number>(0);
+  const { contents: userContents } = userInfo;
+  const userId = userContents?.id ?? 1;
 
   const { ModalUI, setLoginModalState } = useModal();
 
-  useEffect(() => {
-    if (userContents) setUserId(userContents.id);
-  }, [state]);
-
-  const { data: allData, isLoading } = useQuery("lookbooks", apiGet.GET_LOOKS);
+  const { data: allLookbookData, isLoading } = useQuery("lookbooks", apiGet.GET_LOOKS);
 
   return (
     <>
       <Header />
       <ModalUI />
       {isLoading && (
-        <div className="absolute top-1/2 left-1/2 z-50 -translate-x-1/2 -translate-y-1/2">
+        <div className="absolute left-1/2 top-1/2 z-50 -translate-x-1/2 -translate-y-1/2">
           <LoadingSpinner />
         </div>
       )}
       <div>
         <ul className="grid grid-cols-2 pb-10">
-          {allData
+          {allLookbookData
             ?.slice()
             .reverse()
             .map((data: LookbookData) => (
-              <LookItem
-                key={data.id}
-                {...data}
-                userId={userId}
-                setModal={setLoginModalState}
-              />
+              <LookItem key={data.id} {...data} userId={userId || 1} setModal={setLoginModalState} />
             ))}
         </ul>
       </div>
-      <FloatingButton path="/create/post" />
+      <FloatingButton path="/create/style-feed" />
       <Navigation />
     </>
   );

--- a/src/pages/lookbook/index.tsx
+++ b/src/pages/lookbook/index.tsx
@@ -1,17 +1,18 @@
 import { NextPage } from "next";
 import { useQuery } from "react-query";
-import { useEffect, useState } from "react";
+import { useContext } from "react";
 
 import { useRecoilValueLoadable } from "recoil";
 import { currentUserInfoQuery } from "../../recoil/user";
 
 import Header from "../../components/common/header";
 import Navigation from "../../components/common/navigation";
+import Modal from "src/components/common/ui/modal";
 import LookItem from "../../components/lookbook/look-item";
 import FloatingButton from "../../components/common/ui/floating-button";
 import LoadingSpinner from "../../components/common/ui/loading-spinner";
 
-import useModal from "../../hooks/useModal";
+import { modalContext } from "src/context/modal-context";
 import { apiGet } from "../../service/request";
 import { LookbookData } from "../../common/types/data.types";
 
@@ -20,14 +21,14 @@ const Lookbook: NextPage = () => {
   const { contents: userContents } = userInfo;
   const userId = userContents?.id ?? 1;
 
-  const { ModalUI, setLoginModalState } = useModal();
+  const { isOpen, modal } = useContext(modalContext);
 
   const { data: allLookbookData, isLoading } = useQuery("lookbooks", apiGet.GET_LOOKS);
 
   return (
     <>
       <Header />
-      <ModalUI />
+      <Modal isOpen={isOpen} {...modal} />
       {isLoading && (
         <div className="absolute left-1/2 top-1/2 z-50 -translate-x-1/2 -translate-y-1/2">
           <LoadingSpinner />
@@ -39,7 +40,7 @@ const Lookbook: NextPage = () => {
             ?.slice()
             .reverse()
             .map((data: LookbookData) => (
-              <LookItem key={data.id} {...data} userId={userId || 1} setModal={setLoginModalState} />
+              <LookItem key={data.id} {...data} userId={userId || 1} />
             ))}
         </ul>
       </div>

--- a/src/service/query/comment.ts
+++ b/src/service/query/comment.ts
@@ -1,0 +1,30 @@
+import { useMutation, useQueryClient } from "react-query";
+import { apiPost } from "../request";
+import { CreateCommentMutate, DeleteCommentMutate } from "./comment.types";
+
+const BASE_COMMENT_KEY = "comment";
+
+const COMMENT_KEY = {
+  CREATE: [BASE_COMMENT_KEY, "create"],
+  DELETE: [BASE_COMMENT_KEY, "delete"],
+};
+
+export const useCreateComment = ({ postId }: { postId: number }) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationKey: COMMENT_KEY.CREATE,
+    mutationFn: (payload: CreateCommentMutate) => apiPost.CREATE_COMMENT(postId, payload),
+    onSuccess: () => queryClient.invalidateQueries("getPost"),
+  });
+};
+
+export const useDeleteComment = ({ commentId }: { commentId: number }) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationKey: COMMENT_KEY.DELETE,
+    mutationFn: (payload: DeleteCommentMutate) => apiPost.UPDATE_COMMENT(commentId, payload),
+    onSuccess: () => queryClient.invalidateQueries("getPost"),
+  });
+};

--- a/src/service/query/comment.types.ts
+++ b/src/service/query/comment.types.ts
@@ -1,0 +1,8 @@
+export interface CreateCommentMutate {
+  userId: number;
+  comment: string;
+}
+
+export interface DeleteCommentMutate {
+  userId: number;
+}

--- a/src/service/query/lookbook.ts
+++ b/src/service/query/lookbook.ts
@@ -1,0 +1,24 @@
+import { useInfiniteQuery, useQuery } from "react-query";
+import { LookbookData } from "src/common/types/data.types";
+import { apiGet, apiPost } from "../request";
+
+const BASE_LOOKBOOK_KEY = "lookbook";
+
+const LOOKBOOK_KEY = {
+  LIST: [BASE_LOOKBOOK_KEY, "list"],
+};
+
+export const useGetLookBookPost = ({ lookbookId }: { lookbookId: string }) => {
+  return useQuery<LookbookData>(BASE_LOOKBOOK_KEY, () => apiGet.GET_POST(lookbookId), {
+    enabled: !!lookbookId,
+    notifyOnChangeProps: "tracked",
+  });
+};
+
+export const useGetLookBookList = ({ lookbookId }: { lookbookId: string }) => {
+  return useInfiniteQuery(LOOKBOOK_KEY.LIST, ({ pageParam = 1 }) => apiPost.GET_ALL_POST(lookbookId, pageParam), {
+    getNextPageParam: lastPage => lastPage?.nextId ?? false,
+    enabled: !!lookbookId,
+    notifyOnChangeProps: "tracked",
+  });
+};

--- a/src/service/request.ts
+++ b/src/service/request.ts
@@ -49,7 +49,7 @@ const apiPost = {
 
   CREATE_PROFILE: <T extends object>(data: T) => axiosPost("/api/auth/profile", data),
 
-  CREATE_COMMENT: (id: number, data: { comment: any; userId: number }) =>
+  CREATE_COMMENT: (id: number, data: { comment: string; userId: number }) =>
     axiosPost(`/api/look/comment?postId=${id}`, data),
 
   UPDATE_USER: (queryKey: number, data: { productId: number } | { lookId: number | undefined }) =>
@@ -57,7 +57,7 @@ const apiPost = {
 
   UPDATE_NICKNAME: (id: string, data: { nickname: string }) => axiosPost(`/api/user/nickname?id=${id}`, data),
 
-  UPDATE_COMMENT: (id: number, data: { userId: number; comment?: any }) =>
+  UPDATE_COMMENT: (id: number, data: { userId: number; comment?: string }) =>
     axiosPost(`/api/look/comment?commentId=${id}`, data),
 
   UPDATE_VIEWS: (id: number, view: { currentView: number }) => axiosPost(`/api/products/${id}`, view),

--- a/src/service/request.ts
+++ b/src/service/request.ts
@@ -43,37 +43,28 @@ const apiPost = {
 
   CREATE_POST: <T extends object>(data: T) => axiosPost("/api/look", data),
 
-  CREATE_TAG: (data: string[], queryKey: number) =>
-    axiosPost(`/api/user/tag?post=${queryKey}`, data),
+  CREATE_TAG: (data: string[], queryKey: number) => axiosPost(`/api/user/tag?post=${queryKey}`, data),
 
-  CREATE_NICKNAME: (data: { nickname: string }) =>
-    axiosPost("/api/user/nickname", data),
+  CREATE_NICKNAME: (data: { nickname: string }) => axiosPost("/api/user/nickname", data),
 
-  CREATE_PROFILE: <T extends object>(data: T) =>
-    axiosPost("/api/auth/profile", data),
+  CREATE_PROFILE: <T extends object>(data: T) => axiosPost("/api/auth/profile", data),
 
   CREATE_COMMENT: (id: number, data: { comment: any; userId: number }) =>
     axiosPost(`/api/look/comment?postId=${id}`, data),
 
-  UPDATE_USER: (
-    queryKey: number,
-    data: { productId: number } | { lookId: number | undefined },
-  ) => axiosPost(`/api/user/${queryKey}`, data),
+  UPDATE_USER: (queryKey: number, data: { productId: number } | { lookId: number | undefined }) =>
+    axiosPost(`/api/user/${queryKey}`, data),
 
-  UPDATE_NICKNAME: (id: string, data: { nickname: string }) =>
-    axiosPost(`/api/user/nickname?id=${id}`, data),
+  UPDATE_NICKNAME: (id: string, data: { nickname: string }) => axiosPost(`/api/user/nickname?id=${id}`, data),
 
-  UPDATE_COMMENT: (id: number, data: { comment: any; userId: number }) =>
+  UPDATE_COMMENT: (id: number, data: { userId: number; comment?: any }) =>
     axiosPost(`/api/look/comment?commentId=${id}`, data),
 
-  UPDATE_VIEWS: (id: number, view: { currentView: number }) =>
-    axiosPost(`/api/products/${id}`, view),
+  UPDATE_VIEWS: (id: number, view: { currentView: number }) => axiosPost(`/api/products/${id}`, view),
 
-  UPDATE_TAG: (id: number, tags: string[]) =>
-    axiosPost(`/api/user/tag?update=${id}`, tags),
+  UPDATE_TAG: (id: number, tags: string[]) => axiosPost(`/api/user/tag?update=${id}`, tags),
 
-  UPDATE_PROFILE: (data: { imageurl: string; userData: number }) =>
-    axiosPost("/api/user/image", data),
+  UPDATE_PROFILE: (data: { imageurl: string; userData: number }) => axiosPost("/api/user/image", data),
 
   GET_ALL_POST: (id: string, pageParam: string) =>
     axiosPost(`/api/look/post?pageParam=${pageParam}`, { lookbookId: id }),


### PR DESCRIPTION
## PR 목적
룩북 페이지 리팩토링

## 변경 사항
- 컴포넌트 분리: CommentForm, CommentList, ContentsBox
- useComment: 댓글 관련 로직을 커스텀훅으로 분리
- react query커스텀훅 추가
    
    react query요청을 커스텀훅을 통해 보내도록 분리해 **요청 함수 내부에서의 분기처리를 제거하고** 각 요청이 하나의 커스텀훅을 통해 실행될 수 있도록하여 가독성, 유지보수성을 높이는 방향으로 리팩토링 했습니다.
    
    - **lookbook**: useGetLookBookList, useGetLookBookPost
    - **comment**: useCreateComment, useDeleteComment
- modal
    
    모달 커스텀훅 내부에 한번에 포함되어 있던 비즈니스 로직, ui등을 분리하여 각 역할이 명확해지고 유지보수성을 높이는 방향으로 리팩토링을 진행했습니다.
    
    - 모달 메시지, 버튼 텍스트를 상수 파일로 분리
    - useModal에 종속되어 있던 modal컴포넌트 분리
      - 비즈니스 로직 (isOpen, modal관련 함수) →  ModalContext
      - 종류별로 모달을 선택 → useModal
      - ui → Modal
        
## 체크리스트
- [x] 코드가 올바르게 작동하는지 확인했습니다.
- [ ] 문서가 업데이트되었습니다.
- [x] 변경 사항이 정상적으로 작동하는지 수동으로 확인했습니다.

## 스크린샷 (선택사항)
- UI 변경이 있을 경우, 변경된 UI의 스크린샷을 첨부해주세요.
