### PR TITLE
Fix/dimmed overlay

### DIFF
--- a/src/components/common/overlay.tsx
+++ b/src/components/common/overlay.tsx
@@ -2,7 +2,7 @@ import { NextPage } from "next";
 import React from "react";
 
 const Overlay: NextPage = () => {
-  return <div className="fixed left-0 top-0 z-40 h-screen w-[390px] bg-black pt-10 opacity-40" />;
+  return <div className="fixed top-0 z-40 h-screen w-[390px] bg-black pt-10 opacity-40" />;
 };
 
 export default Overlay;

--- a/src/components/mypage/profile/keyword-form.tsx
+++ b/src/components/mypage/profile/keyword-form.tsx
@@ -49,8 +49,8 @@ const KeywordForm = ({ userData, setToast }: ProfileFormProps) => {
     <>
       {isTabOpen && (
         <>
-          <Overlay />
-          <div className="fixed bottom-0 left-0 z-50 w-[390px]">
+          <div className="fixed top-0 z-40 h-screen w-[390px] translate-x-[-20px] bg-black pt-10 opacity-40" />
+          <div className="fixed bottom-0 z-50 w-[390px] translate-x-[-20px]">
             <form
               onSubmit={handleSubmit}
               className="h-16 w-full justify-center border-b-[1px] border-solid border-black bg-white p-5 text-center shadow-2xl shadow-black "


### PR DESCRIPTION
## PR 목적
dimmed된 배경 css수정

## 설명
모달이 뜰 때 뒤쪽배경 위치가 어긋나는 현상 발생.
- 원인: 프로필 페이지에서의 css수정이 다른 페이지까지 영향.
- 해결: css를 수정했습니다. 

## 변경 사항
- overlay.tsx: 기존 css로 수정.
- profile/keyword-form.tsx: 공통 Overlay컴포넌트 사용X 

## 체크리스트
- [x] 코드가 올바르게 작동하는지 확인했습니다.
- [ ] 문서가 업데이트되었습니다.
- [x] 변경 사항이 정상적으로 작동하는지 수동으로 확인했습니다.

## 스크린샷 (선택사항)
<img width="426" alt="image" src="https://github.com/user-attachments/assets/62d676ae-016c-4fb5-bd08-eb6017744ead">

